### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.pyload.org


### PR DESCRIPTION
Sorry vuolter, I didn't check the pyload.org DNS records before submitting the patch, assuming DNS has already been configured to point to github.io.
Please delete CNAME from repo until the following record has been created in pyload.org DNS records:
CNAME www.pyload.org pyload.github.io

Without the proper DNS records for pyload.org adding CNAME to repository seems to break pyload.github.io.
